### PR TITLE
Related projects: updated project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A collection of awesome Spacemacs resources
 
 
 ## Related Projects
-- [intelli-space: Spacemacs' like key bindings for IntelliJ platform](https://github.com/MarcoIeni/intelli-space) 
+- [intellimacs: Spacemacs' like key bindings for IntelliJ platform](https://github.com/MarcoIeni/intellimacs) 
 - [Spaceclipse: Spacemacs' like key bindings for Eclipse](https://github.com/MarcoIeni/spaceclipse) 
 - [VSpaceCode: Spacemacs' like key bindings for Visual Studio Code](https://github.com/VSpaceCode/VSpaceCode)
 


### PR DESCRIPTION
Updated intelli-space name, since it has been renamed to intellimacs.
I had to rename the project because intellispace is a registered trademark.
